### PR TITLE
Fixed type-cast error

### DIFF
--- a/python/raspberrypi/DFRobot_HumanDetection.py
+++ b/python/raspberrypi/DFRobot_HumanDetection.py
@@ -765,7 +765,7 @@ class DFRobot_HumanDetection:
 
             if self.ser.in_waiting > 0:
                 data = self.ser.read(1)[0]
-                data = ord(data)
+                # data = ord(data)          # Expects string and not int
                 #print(data)
                 #timeStart = time.time()
 


### PR DESCRIPTION
Fixed the below error

`TypeError: ord() expected string of length 1, but int found `

in DFRobot_HumanDetection.py Line number 768
